### PR TITLE
switched from oraclejdk7 to oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk7
+  - oraclejdk8
   - openjdk7
 
 before_script:


### PR DESCRIPTION
oraclejdk7 is not supported by Travis anymore. Read more about this at https://github.com/travis-ci/travis-ci/issues/7019. We still use openjdk7 for java7 builds.